### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
   repositories {
     add(new org.apache.ivy.plugins.resolver.URLResolver()) {
       name = 'GitHub'
-      addArtifactPattern 'http://cloud.github.com/downloads/[organisation]/[module]/[module]-[revision].[ext]'
+      addArtifactPattern 'https://cloud.github.com/downloads/[organisation]/[module]/[module]-[revision].[ext]'
     }
   }
 
@@ -31,9 +31,9 @@ buildscript {
 }
 
 repositories {
-  maven { url "http://repo.springsource.org/libs-snapshot" }
-  maven { url "http://repo.springsource.org/libs-milestone" }
-  maven { url "http://repo.springsource.org/libs-release" }
+  maven { url "https://repo.springsource.org/libs-snapshot" }
+  maven { url "https://repo.springsource.org/libs-milestone" }
+  maven { url "https://repo.springsource.org/libs-release" }
 }
 
 dependencies {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://cloud.github.com/downloads/ (UnknownHostException) migrated to:  
  https://cloud.github.com/downloads/ ([https](https://cloud.github.com/downloads/) result UnknownHostException).

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-release migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).