### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/org/springframework/data/rest/example/EntityLoader.java
+++ b/src/main/java/org/springframework/data/rest/example/EntityLoader.java
@@ -36,7 +36,7 @@ public class EntityLoader {
     ));
     LOG.info("  **** Saved Address: " + addr);
 
-    Profile twitter = profiles.save(new Profile("twitter", "http://twitter.com/john_doe"));
+    Profile twitter = profiles.save(new Profile("twitter", "https://twitter.com/john_doe"));
     LOG.info("  **** Saved Profile: " + twitter);
 
     Map<String, Profile> profs = new HashMap<String, Profile>();


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://twitter.com/john_doe with 1 occurrences migrated to:  
  https://twitter.com/john_doe ([https](https://twitter.com/john_doe) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/spring-data-rest-webmvc/ with 1 occurrences